### PR TITLE
Searchpage Update

### DIFF
--- a/app/containers/NavBar/index.js
+++ b/app/containers/NavBar/index.js
@@ -10,14 +10,13 @@ import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { createStructuredSelector } from 'reselect';
 import { compose } from 'redux';
-import { goBack } from 'react-router-redux';
+import { goBack, push } from 'react-router-redux';
 import { Navbar, Nav, NavItem, FormGroup, FormControl, Button } from 'react-bootstrap';
 import { LinkContainer } from 'react-router-bootstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import arrowLeft from '@fortawesome/fontawesome-free-solid/faArrowLeft';
 import { Link } from 'react-router-dom';
 import { makeSelectLocation } from 'containers/App/selectors';
-import { basicSearch } from 'containers/SearchPage/actions';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
@@ -37,6 +36,24 @@ export class NavBar extends React.Component { // eslint-disable-line react/prefe
     super(props);
     this.search = null;
     this.submit = this.submit.bind(this);
+    this.onTextEnter = this.onTextEnter.bind(this);
+
+    let searchQuery = this.props.location.search;
+    // if the search is set it will be set with ?q={somthing}
+    // to make quick and easy simply removing ?q=
+    if (searchQuery.length > 3) {
+      searchQuery = searchQuery.slice(3);
+    }
+
+    this.state = {
+      input: searchQuery,
+    };
+  }
+
+  onTextEnter() {
+    this.setState({
+      input: this.search.value,
+    });
   }
 
   logout() {
@@ -45,7 +62,7 @@ export class NavBar extends React.Component { // eslint-disable-line react/prefe
 
   submit() {
     if (this.search !== null) {
-      this.props.dispatch(basicSearch(this.search.value));
+      this.props.dispatch(push(`/search?q=${this.search.value}`));
     }
   }
 
@@ -89,7 +106,7 @@ export class NavBar extends React.Component { // eslint-disable-line react/prefe
                 <Navbar.Form pullLeft key={1}>
                   <form onSubmit={(evt) => { evt.preventDefault(); this.submit(); }} >
                     <FormGroup>
-                      <FormControl type="text" placeholder="Search" inputRef={(ref) => { this.search = ref; }} />{' '}
+                      <FormControl value={this.state.input} onChange={this.onTextEnter} type="text" placeholder="Search" inputRef={(ref) => { this.search = ref; }} />{' '}
                       <Button type="submit">Submit</Button>
                     </FormGroup>
                   </form>
@@ -128,6 +145,7 @@ NavBar.propTypes = {
   dispatch: PropTypes.func.isRequired,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
+    search: PropTypes.string.isRequired,
   }).isRequired,
 };
 

--- a/app/containers/NavBar/saga.js
+++ b/app/containers/NavBar/saga.js
@@ -1,6 +1,19 @@
-// import { take, call, put, select } from 'redux-saga/effects';
+import { call, takeLatest } from 'redux-saga/effects';
+import { LOCATION_CHANGE } from 'react-router-redux';
+import { basicSearch as basicSearchSaga } from 'containers/SearchPage/saga';
+import { basicSearch as basicSearchAction } from 'containers/SearchPage/actions';
+
+export function* search(action) {
+  if (action.payload.pathname === '/search') {
+    let query = action.payload.search;
+    if (query.length > 3) {
+      query = query.slice(3);
+      yield call(basicSearchSaga, basicSearchAction(query));
+    }
+  }
+}
 
 // Individual exports for testing
 export default function* defaultSaga() {
-  // See example in containers/HomePage/saga.js
+  yield takeLatest(LOCATION_CHANGE, search);
 }

--- a/app/containers/SearchPage/actions.js
+++ b/app/containers/SearchPage/actions.js
@@ -40,10 +40,11 @@ export function errorSearch(err) {
   };
 }
 
-export function searchResults(payload, searchType) {
+export function searchResults(payload, searchType, query) {
   return {
     type: SEARCH_RESULTS,
     payload,
     searchType,
+    query,
   };
 }

--- a/app/containers/SearchPage/index.js
+++ b/app/containers/SearchPage/index.js
@@ -20,12 +20,18 @@ import makeSelectSearchPage, { makeSelectSearchResults, makeSelectSearchType, ma
 import reducer from './reducer';
 import saga from './saga';
 import messages from './messages';
+import { basicSearch } from './actions';
 
 export class SearchPage extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
     super(props);
     this.tableNames = ['No Results for Current Query'];
     this.handleSelect = this.handleSelect.bind(this);
+    let query = props.location.search;
+    if (query.length > 3) {
+      query = query.slice(3);
+      props.dispatch(basicSearch(query));
+    }
 
     this.state = {
       currentTable: 0,
@@ -128,10 +134,14 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
 }
 
 SearchPage.propTypes = {
+  dispatch: PropTypes.func.isRequired,
   results: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.array,
   ]).isRequired,
+  location: PropTypes.shape({
+    search: PropTypes.string.isRequired,
+  }),
   searchType: PropTypes.string.isRequired,
   searchedQuery: PropTypes.string.isRequired,
 };

--- a/app/containers/SearchPage/index.js
+++ b/app/containers/SearchPage/index.js
@@ -16,7 +16,7 @@ import ItemTable from 'components/ItemTable';
 
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
-import makeSelectSearchPage, { makeSelectSearchResults, makeSelectSearchType } from './selectors';
+import makeSelectSearchPage, { makeSelectSearchResults, makeSelectSearchType, makeSelectSearchedQuery } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
 import messages from './messages';
@@ -92,22 +92,36 @@ export class SearchPage extends React.Component { // eslint-disable-line react/p
     }
 
     return (
-      <div>
-        <Col xs={10} xsOffset={1}>
-          <Helmet>
-            <title>SearchPage</title>
-            <meta name="description" content="Description of SearchPage" />
-          </Helmet>
-          {
-            (tabs.length !== 0) ?
-            (<Nav bsStyle="tabs" onSelect={(k) => this.handleSelect(k)}>
-              {tabs}
-            </Nav>) : ''
-          }
-          <Panel>
-            {itemTable}
-          </Panel>
-        </Col>
+      <div style={{ marginTop: '50px' }}>
+        <Row>
+          <Col xs={10} xsOffset={1}>
+            <Panel bsStyle="info">
+              <Panel.Body>
+                <FormattedMessage
+                  id="app.components.SearchPage.querySearched"
+                  defaultMessage={`Showing results for search: ${this.props.searchedQuery}`}
+                />
+              </Panel.Body>
+            </Panel>
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={10} xsOffset={1}>
+            <Helmet>
+              <title>SearchPage</title>
+              <meta name="description" content="Description of SearchPage" />
+            </Helmet>
+            {
+              (tabs.length !== 0) ?
+              (<Nav bsStyle="tabs" onSelect={(k) => this.handleSelect(k)}>
+                {tabs}
+              </Nav>) : ''
+            }
+            <Panel>
+              {itemTable}
+            </Panel>
+          </Col>
+        </Row>
       </div>
     );
   }
@@ -119,12 +133,14 @@ SearchPage.propTypes = {
     PropTypes.array,
   ]).isRequired,
   searchType: PropTypes.string.isRequired,
+  searchedQuery: PropTypes.string.isRequired,
 };
 
 const mapStateToProps = createStructuredSelector({
   searchpage: makeSelectSearchPage(),
   results: makeSelectSearchResults(),
   searchType: makeSelectSearchType(),
+  searchedQuery: makeSelectSearchedQuery(),
 });
 
 function mapDispatchToProps(dispatch) {

--- a/app/containers/SearchPage/reducer.js
+++ b/app/containers/SearchPage/reducer.js
@@ -14,6 +14,7 @@ import {
 const initialState = fromJS({
   searchResults: {},
   searchType: '',
+  searchedQuery: '',
   err: {
     errored: false,
     msg: '',
@@ -32,7 +33,8 @@ function searchPageReducer(state = initialState, action) {
       return state
         .set('searchResults', fromJS(action.payload))
         .setIn(['err', 'errored'], false)
-        .set('searchType', action.searchType);
+        .set('searchType', action.searchType)
+        .set('searchedQuery', action.query);
     default:
       return state;
   }

--- a/app/containers/SearchPage/saga.js
+++ b/app/containers/SearchPage/saga.js
@@ -14,7 +14,7 @@ export function* basicSearch(action) {
   try {
     const data = yield call(request, requestUrl, options);
     if (data.success) {
-      yield put(searchResults(data.payload, 'basic'));
+      yield put(searchResults(data.payload, 'basic', action.query));
     } else {
       throw new Error(data.err);
     }

--- a/app/containers/SearchPage/selectors.js
+++ b/app/containers/SearchPage/selectors.js
@@ -18,6 +18,11 @@ const makeSelectSearchType = () => createSelector(
   (substate) => substate.get('searchType')
 );
 
+const makeSelectSearchedQuery = () => createSelector(
+  selectSearchPageDomain,
+  (substate) => substate.get('searchedQuery')
+);
+
 /**
  * Default selector used by SearchPage
  */
@@ -32,4 +37,5 @@ export {
   selectSearchPageDomain,
   makeSelectSearchResults,
   makeSelectSearchType,
+  makeSelectSearchedQuery,
 };


### PR DESCRIPTION
Seeks to solve (#2)
Update to the search dispatch method. (See details bellow) 
- This is not an elegant way to handle the search and is in need
  of a refactor. However, it is functional and doesn't impose any
  oddities on the programmers using it other than one minor detail.

- The pattern goes as follows, no longer use the basicSearch action
  instead dispatch a push to the /search route with the query param.
  ex. /search?q=thing would search for thing.

- The calling of the basic search now occurs based on the
  LOCATION_CAHNGE action. The navBar will detect the route and grab
  the query. If there is a query it will dispatch the request.

- The basicSearch is still functional and will put the results in
  store however the url will not stay up-to-date. If this is ok for
  your use then you may use basicSearch action to do so. Otherwise,
  use the above mentioned method.

- The search page will also automatically search for the param in the
  url when it is hit directly from url. (If the user has direct link to the page)